### PR TITLE
Add rules, fix the problem can not use /link

### DIFF
--- a/src/SimpleAuth/SimpleAuth.php
+++ b/src/SimpleAuth/SimpleAuth.php
@@ -323,7 +323,7 @@ class SimpleAuth extends PluginBase{
 				$oldIGN = $args[0];
 				$oldPWD = $args[1];
 				$linked = $this->getDataProvider()->getLinked($sender->getName());
-				if(strtolower($sender->getName()) === strtolower($linked)){
+				if($linked !== null and $linked !== "" and strtolower($sender->getName()) === strtolower($linked)){
 					$sender->sendMessage(TextFormat::RED . ($this->getMessage("link.sameign") ?? "You cannot link to the same account you are using"));
 					return true;
 				}


### PR DESCRIPTION
[Server thread/CRITICAL]: 於 link 執行指令 “link artisew 6666666“ 時，出現了未被處理的錯誤： strtolower() expects parameter 1 to be string, null given
[Server thread/CRITICAL]: TypeError: "strtolower() expects parameter 1 to be string, null given" (EXCEPTION) in "SimpleAuth-master/src/SimpleAuth/SimpleAuth" at line 326