### PR TITLE
Uncommented dataProviderSettings

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -5,14 +5,13 @@
 #Be aware that data is not automatically moved between data providers.
 dataProvider: yaml
 
-#For MySQL:
-#dataProviderSettings:
-# host: "127.0.0.1"
-# port: 3306
-# user: "user"
-# password: "password"
-# database: "databaseName"
-dataProviderSettings: []
+#For MySQL only. Ignore these settings if dataProvider is not mysql.
+dataProviderSettings:
+  host: "127.0.0.1"
+  port: 3306
+  user: "user"
+  password: "password"
+  database: "databaseName"
 
 #If enabled, existing logged-in accounts won't be kicked if a new player joins with the same name
 forceSingleSession: true


### PR DESCRIPTION
I don't know why @shoghicp thought it'd be good to comment out the settings the user probably won't need and leave a placeholder value behind. Telling the player not to touch it if they don't use MySQL is much better than expecting users unfamiliar with YAML syntax to figure out the proper way to uncomment it. 10 out of 10 humans unfamiliar with YAML syntax will believe that they do not need to keep the space after deleting the #.